### PR TITLE
Window title settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ OPTIONS:
         --texture2 <texture2>    Path to 2D RGBA texture for iChannel2
         --texture3 <texture3>    Path to 2D RGBA texture for iChannel3
     -W, --width <width>          Sets window width [default: 600]
+    -t, --title <title>          Sets the window title
 
 ARGS:
     <shader>    Path to fragment shader [default: shaders/default.frag]

--- a/src/argvalues.rs
+++ b/src/argvalues.rs
@@ -21,6 +21,9 @@ pub struct ArgValues {
     // Some(id) if downloading a shader
     pub getid: Option<String>,
 
+    // a custom window title
+    pub title: Option<String>,
+
     // true if also running downloaded shader
     pub andrun: bool,
 }
@@ -50,6 +53,9 @@ impl ArgValues {
         let texture2path = matches.value_of("texture2").map(&str_to_string);
         let texture3path = matches.value_of("texture3").map(&str_to_string);
 
+        // Window title
+        let title = matches.value_of("title").map(&str_to_string);
+
         // Check to see if they want to download a shader (and then run it)
         let (getid, andrun) = if let Some(getmatches) = matches.subcommand_matches("get") {
             (
@@ -71,6 +77,7 @@ impl ArgValues {
             examplename,
             getid,
             andrun,
+            title,
         })
     }
 }

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -60,3 +60,8 @@ args:
         takes_value: true
         index: 1
         help: Path to fragment shader
+    - title:
+        long: title
+        short: t
+        takes_value: true
+        help: Sets the window title

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -102,8 +102,25 @@ pub fn run(av: ArgValues) -> error::Result<()> {
     });
 
     let event_loop = EventLoop::new();
+
+    let shader_name = av
+        .getid
+        .as_ref()
+        .or(av.shaderpath.as_ref())
+        .or(av.examplename.as_ref());
+    let shader_title = shader_name.map(|name| format!("{} - shadertoy-rs", name));
+    let default_title = "shadertoy-rs".to_string();
+
+    let window_title = if av.title.is_some() {
+        av.title.as_ref()
+    } else if shader_title.is_some() {
+        shader_title.as_ref()
+    } else {
+        Some(&default_title)
+    };
+
     let window_config = WindowBuilder::new()
-        .with_title("shadertoy-rs")
+        .with_title(window_title.unwrap())
         .with_inner_size(glutin::dpi::PhysicalSize::new(width, height));
 
     let (window, mut device, mut factory, main_color, mut main_depth) =


### PR DESCRIPTION
I added a `--title` option to set the window title.  If `--title <title>` is set, the window title will be "_<title>_".  Otherwise, the title will be "_<shader_name>_ - shadertoy-rs" where `shader_name` is either the shadertoy id or the example name.