### PR TITLE
Support for texture filtering and mipmap generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ OPTIONS:
                                  [possible values: clamp, tile, mirror, border]
         --wrap3 <wrap3>          Wrap mode for iChannel3 [default: clamp]
                                  [possible values: clamp, tile, mirror, border]
+        --filter0 <filter0>      Filtering for iChannel0 [default: mipmap]
+                                 [possible values: scale, mipmap, bilinear, trilinear, anisotropic]
+        --filter1 <filter1>      Filtering for iChannel1 [default: mipmap]
+                                 [possible values: scale, mipmap, bilinear, trilinear, anisotropic]
+        --filter2 <filter2>      Filtering for iChannel2 [default: mipmap]
+                                 [possible values: scale, mipmap, bilinear, trilinear, anisotropic]
+        --filter3 <filter3>      Filtering for iChannel3 [default: mipmap]
+                                 [possible values: scale, mipmap, bilinear, trilinear, anisotropic]
+        --anisotropic_max <max>  Max steepness for anisotropic filtering (1-16) [default: 1]
+
 
 ARGS:
     <shader>    Path to fragment shader

--- a/src/argvalues.rs
+++ b/src/argvalues.rs
@@ -1,5 +1,5 @@
 use error;
-use gfx::texture::WrapMode;
+use gfx::texture::{WrapMode, FilterMethod};
 
 use clap::App;
 
@@ -21,6 +21,15 @@ pub struct ArgValues {
     pub wrap1: Option<WrapMode>,
     pub wrap2: Option<WrapMode>,
     pub wrap3: Option<WrapMode>,
+
+    // Filter method
+    pub filter0: Option<FilterMethod>,
+    pub filter1: Option<FilterMethod>,
+    pub filter2: Option<FilterMethod>,
+    pub filter3: Option<FilterMethod>,
+
+    // Max value for anisotropic filtering
+    pub anisotropic_max: Option<u8>,
 
     // Some(name) if running an example
     pub examplename: Option<String>,
@@ -44,6 +53,14 @@ impl ArgValues {
         // Closure for converting &str to String
         let str_to_string = |s: &str| s.to_string();
 
+        // Convert &str to integer between 1 and 16
+        fn str_to_anisotropic_max(s: &str) -> u8 {
+            match s.parse::<u8>() {
+                Ok(i) => i.clamp(1,16),
+                Err(_e) => 1,
+            }
+        }
+
         // Match &str to WrapMode
         let str_to_wrapmode = |s: &str| {
             match s {
@@ -54,6 +71,7 @@ impl ArgValues {
                 _ => WrapMode::Clamp,
             }
         };
+
 
         // Window dimensions
         let width = matches.value_of("width").unwrap().parse()?;
@@ -76,6 +94,27 @@ impl ArgValues {
         let wrap1 = matches.value_of("wrap1").map(&str_to_wrapmode);
         let wrap2 = matches.value_of("wrap2").map(&str_to_wrapmode);
         let wrap3 = matches.value_of("wrap3").map(&str_to_wrapmode);
+
+        // Anistropic filter max value
+        let anisotropic_max = matches.value_of("anisotropic_max").map(&str_to_anisotropic_max);
+
+        // Match &str to FilterMethod
+        let str_to_filtermethod = |s: &str| {
+            match s {
+                "scale" => FilterMethod::Scale,
+                "mipmap" => FilterMethod::Mipmap,
+                "bilinear" => FilterMethod::Bilinear,
+                "trilinear" => FilterMethod::Trilinear,
+                "anisotropic" => FilterMethod::Anisotropic(anisotropic_max.unwrap()),
+                _ => FilterMethod::Bilinear,
+            }
+        };
+
+        // Texture wrapping
+        let filter0 = matches.value_of("filter0").map(&str_to_filtermethod);
+        let filter1 = matches.value_of("filter1").map(&str_to_filtermethod);
+        let filter2 = matches.value_of("filter2").map(&str_to_filtermethod);
+        let filter3 = matches.value_of("filter3").map(&str_to_filtermethod);
 
         // Window title
         let title = matches.value_of("title").map(&str_to_string);
@@ -102,6 +141,11 @@ impl ArgValues {
             wrap1,
             wrap2,
             wrap3,
+            filter0,
+            filter1,
+            filter2,
+            filter3,
+            anisotropic_max,
             examplename,
             getid,
             andrun,

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -73,6 +73,35 @@ args:
         default_value: "clamp"
         possible_values: ["clamp", "tile", "mirror", "border"]
         help: Wrap mode for iChannel3
+    - filter0:
+        long: filter0
+        takes_value: true
+        default_value: "mipmap"
+        possible_values: ["scale", "mipmap", "bilinear", "trilinear", "anisotropic"]
+        help: Filtering for iChannel0
+    - filter1:
+        long: filter1
+        takes_value: true
+        default_value: "mipmap"
+        possible_values: ["scale", "mipmap", "bilinear", "trilinear", "anisotropic"]
+        help: Filtering for iChannel1
+    - filter2:
+        long: filter2
+        takes_value: true
+        default_value: "mipmap"
+        possible_values: ["scale", "mipmap", "bilinear", "trilinear", "anisotropic"]
+        help: Filtering for iChannel2
+    - filter3:
+        long: filter3
+        takes_value: true
+        default_value: "mipmap"
+        possible_values: ["scale", "mipmap", "bilinear", "trilinear", "anisotropic"]
+        help: Filtering for iChannel3
+    - anisotropic_max:
+        long: anisotropic_max
+        help: Max steepness for anisotropic filtering (1-16)
+        takes_value: true
+        default_value: "1"
     - example:
         short: e
         long: example

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3,6 +3,7 @@ use download;
 use error;
 use gfx;
 use gfx::texture;
+use gfx::texture::FilterMethod;
 use gfx::Factory;
 use loader;
 
@@ -147,6 +148,18 @@ pub fn run(av: ArgValues) -> error::Result<()> {
     let texture2 = loader::load_texture(&TextureId::TWO, &av.texture2path, &mut factory)?;
     let texture3 = loader::load_texture(&TextureId::THREE, &av.texture3path, &mut factory)?;
 
+    let needs_mipmap = |mode: Option<FilterMethod>| match mode.unwrap() {
+        FilterMethod::Scale => false,
+        FilterMethod::Bilinear => false,
+        _ => true
+    };
+
+    // generate mipmaps if they're needed
+    if needs_mipmap(av.filter0) {encoder.generate_mipmap(&texture0)};
+    if needs_mipmap(av.filter1) {encoder.generate_mipmap(&texture1)};
+    if needs_mipmap(av.filter2) {encoder.generate_mipmap(&texture2)};
+    if needs_mipmap(av.filter3) {encoder.generate_mipmap(&texture3)};
+
     let mut data = pipe::Data {
         vbuf: vertex_buffer,
 
@@ -159,28 +172,28 @@ pub fn run(av: ArgValues) -> error::Result<()> {
         i_channel0: (
             texture0,
             factory.create_sampler(texture::SamplerInfo::new(
-                texture::FilterMethod::Bilinear,
+                av.filter0.unwrap(),
                 av.wrap0.unwrap(),
             )),
         ),
         i_channel1: (
             texture1,
             factory.create_sampler(texture::SamplerInfo::new(
-                texture::FilterMethod::Bilinear,
+                av.filter1.unwrap(),
                 av.wrap1.unwrap(),
             )),
         ),
         i_channel2: (
             texture2,
             factory.create_sampler(texture::SamplerInfo::new(
-                texture::FilterMethod::Bilinear,
+                av.filter2.unwrap(),
                 av.wrap2.unwrap(),
             )),
         ),
         i_channel3: (
             texture3,
             factory.create_sampler(texture::SamplerInfo::new(
-                texture::FilterMethod::Bilinear,
+                av.filter3.unwrap(),
                 av.wrap3.unwrap(),
             )),
         ),


### PR DESCRIPTION
One more!  This adds support for the various gfx-rs `FilterMethod` modes.  ~Currently it generates mipmaps by default for all four textures, even if the `FilterMethod` doesn't require it.~

edit: I updated this so it only generates mipmaps on textures that require it