### PR TITLE
Add option to force SRGB off within opengl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,6 +2591,7 @@ dependencies = [
  "env_logger",
  "gfx",
  "gfx_device_gl",
+ "gfx_gl",
  "gfx_window_glutin",
  "glutin 0.27.0",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ notify = "4.0.3"
 reqwest = "~0.9"
 clippy = { version = "0.*", optional = true }
 anyhow = "1.0.0"
+gfx_gl = "0.6.1"
 
 [[bin]]
 path = "src/main.rs"

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ Federico Menozzi <federicogmenozzi@gmail.com>
 Desktop client for Shadertoy
 
 USAGE:
-    shadertoy [OPTIONS] [shader] [SUBCOMMAND]
+    shadertoy [FLAGS] [OPTIONS] [shader] [SUBCOMMAND]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+        --force_srgb_off    Forces srgb to be off. (Use this you have color blending issues)
+    -h, --help              Prints help information
+    -V, --version           Prints version information
 
 OPTIONS:
     -e, --example <example>      Run example shader from examples/ directory

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ USAGE:
     shadertoy [FLAGS] [OPTIONS] [shader] [SUBCOMMAND]
 
 FLAGS:
-        --force-srgb-off    Forces SRGB to be off (replicates shadertoy.com color blending)
+        --force_srgb_off    Forces SRGB to be off (replicates shadertoy.com color blending)
     -h, --help              Prints help information
     -V, --version           Prints version information
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ USAGE:
     shadertoy [FLAGS] [OPTIONS] [shader] [SUBCOMMAND]
 
 FLAGS:
-        --force_srgb_off    Forces srgb to be off. (Use this you have color blending issues)
+        --force-srgb-off    Forces SRGB to be off (replicates shadertoy.com color blending)
     -h, --help              Prints help information
     -V, --version           Prints version information
 

--- a/src/argvalues.rs
+++ b/src/argvalues.rs
@@ -121,7 +121,7 @@ impl ArgValues {
             (None, false)
         };
 
-        let force_srgb_off = matches.is_present("force_srgb_off");
+        let force_srgb_off = matches.is_present("force-srgb-off");
 
         Ok(ArgValues {
             width,

--- a/src/argvalues.rs
+++ b/src/argvalues.rs
@@ -43,6 +43,9 @@ pub struct ArgValues {
 
     // True if also running downloaded shader.
     pub andrun: bool,
+
+    // True if we should force disable srgb
+    pub force_srgb_off: bool,
 }
 
 impl ArgValues {
@@ -118,6 +121,8 @@ impl ArgValues {
             (None, false)
         };
 
+        let force_srgb_off = matches.is_present("force_srgb_off");
+
         Ok(ArgValues {
             width,
             height,
@@ -139,6 +144,7 @@ impl ArgValues {
             getid,
             andrun,
             title,
+            force_srgb_off,
         })
     }
 }

--- a/src/argvalues.rs
+++ b/src/argvalues.rs
@@ -121,7 +121,7 @@ impl ArgValues {
             (None, false)
         };
 
-        let force_srgb_off = matches.is_present("force-srgb-off");
+        let force_srgb_off = matches.is_present("force_srgb_off");
 
         Ok(ArgValues {
             width,

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -118,3 +118,8 @@ args:
         short: t
         takes_value: true
         help: Sets the window title
+    - force_srgb_off:
+          long: force_srgb_off
+          takes_value: false
+          required: false
+          help: Forces srgb to be off. (Use this you have color blending issues)

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -118,8 +118,8 @@ args:
         short: t
         takes_value: true
         help: Sets the window title
-    - force-srgb-off:
-          long: force-srgb-off
+    - force_srgb_off:
+          long: force_srgb_off
           takes_value: false
           required: false
           help: Forces SRGB to be off (replicates shadertoy.com color blending)

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -118,8 +118,8 @@ args:
         short: t
         takes_value: true
         help: Sets the window title
-    - force_srgb_off:
-          long: force_srgb_off
+    - force-srgb-off:
+          long: force-srgb-off
           takes_value: false
           required: false
-          help: Forces srgb to be off. (Use this you have color blending issues)
+          help: Forces SRGB to be off (replicates shadertoy.com color blending)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -133,6 +133,14 @@ pub fn run(av: ArgValues) -> error::Result<()> {
             .unwrap()
             .init_gfx::<ColorFormat, DepthFormat>();
 
+    if av.force_srgb_off {
+        unsafe {
+            device.with_gl(|gl| {
+                gl.Disable(gfx_gl::FRAMEBUFFER_SRGB);
+            })
+        }
+    }
+
     let mut encoder = gfx::Encoder::from(factory.create_command_buffer());
 
     let mut pso = factory


### PR DESCRIPTION
Following issue https://github.com/fmenozzi/shadertoy-rs/issues/29

By default, GFX enables FRAMEBUFFER_SRGB in OpenGL. Even if shadertoy only uses RGBA at some point the conversion to SRGB is made which leads to disparities between shadertoy.com's rendering and shadertoy-rs's. This PR adds the option to disable FRAMEBUFFER_SRGB in OpenGL with a flag. 

Unsafe has to be used in this case.

[Shader used to compare changes](https://www.shadertoy.com/view/ttB3Rh).

Before:
![image](https://github.com/fmenozzi/shadertoy-rs/assets/4690919/851dc7f4-5ca3-4098-84de-d745fd42d255)

After:
![image](https://github.com/fmenozzi/shadertoy-rs/assets/4690919/41f64f1d-1ee3-4204-a4e3-612562a6c796)

For more details see initial issue as well as : 
- https://github.com/gfx-rs/gfx/issues/997
- https://github.com/gfx-rs/gfx/issues/1915